### PR TITLE
Add filtered_api config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Vagrant.configure("2") do |config|
     ovirt.password = "password"
     ovirt.insecure = true
     ovirt.debug = true
+    ovirt.filtered_api = true #see http://www.ovirt.org/develop/release-management/features/infra/user-portal-permissions/
     ovirt.cluster = 'Default'
     ovirt.template = 'Vagrant-Centos7-test'
     ovirt.console = 'vnc'

--- a/lib/vagrant-ovirt4/action/connect_ovirt.rb
+++ b/lib/vagrant-ovirt4/action/connect_ovirt.rb
@@ -21,6 +21,7 @@ module VagrantPlugins
           conn_attr[:password] = config.password if config.password
           conn_attr[:debug] = config.debug if config.debug
           conn_attr[:insecure] = true if config.insecure
+          conn_attr[:headers] = {'Filter' => true} if config.filtered_api
 
           @logger.info("Connecting to oVirt (#{config.url}) ...")
           OVirtProvider.ovirt_connection = OvirtSDK4::Connection.new(conn_attr)          

--- a/lib/vagrant-ovirt4/config.rb
+++ b/lib/vagrant-ovirt4/config.rb
@@ -11,6 +11,7 @@ module VagrantPlugins
       attr_accessor :password
       attr_accessor :insecure
       attr_accessor :debug
+      attr_accessor :filtered_api
       attr_accessor :cpu_cores
       attr_accessor :cpu_sockets
       attr_accessor :cpu_threads
@@ -31,6 +32,7 @@ module VagrantPlugins
         @password          = UNSET_VALUE
         @insecure          = UNSET_VALUE
         @debug             = UNSET_VALUE
+        @filtered_api      = UNSET_VALUE
         @cpu_cores         = UNSET_VALUE
         @cpu_sockets       = UNSET_VALUE
         @cpu_threads       = UNSET_VALUE
@@ -53,6 +55,7 @@ module VagrantPlugins
         @password = nil if @password == UNSET_VALUE
         @insecure = false if @insecure == UNSET_VALUE
         @debug = false if @debug == UNSET_VALUE
+        @filtered_api = false if @filtered_api == UNSET_VALUE
         @cpu_cores = 1 if @cpu_cores == UNSET_VALUE
         @cpu_sockets = 1 if @cpu_sockets == UNSET_VALUE
         @cpu_threads = 1 if @cpu_threads == UNSET_VALUE

--- a/spec/vagrant-ovirt4/config_spec.rb
+++ b/spec/vagrant-ovirt4/config_spec.rb
@@ -33,6 +33,7 @@ describe VagrantPlugins::OVirtProvider::Config do
     its("password")          { should be_nil }
     its("insecure")          { should == false }
     its("debug")             { should == false }
+    its("filtered_api")      { should == false }
     its("cpu_cores")         { should == 1 }
     its("cpu_sockets")       { should == 1 }
     its("cpu_threads")       { should == 1 }
@@ -50,7 +51,7 @@ describe VagrantPlugins::OVirtProvider::Config do
   end
 
   describe "overriding defaults" do
-    [:url, :username, :password, :insecure, :debug, :cpu_cores, :cpu_sockets, :cpu_threads, :cluster, :console, :template, :cloud_init, :placement_host, :bios_serial].each do |attribute|
+    [:url, :username, :password, :insecure, :debug, :filtered_api, :cpu_cores, :cpu_sockets, :cpu_threads, :cluster, :console, :template, :cloud_init, :placement_host, :bios_serial].each do |attribute|
 
       it "should not default #{attribute} if overridden" do
         instance.send("#{attribute}=".to_sym, "foo")


### PR DESCRIPTION
Closes #59.
This allows adding `Filter: true` http header to each oVirt API call (needed for non-admin users).

Sample usage in Vagrantfile:
```ruby
ovirt.filtered_api = true
```