### PR TITLE
Add box handling to get_state

### DIFF
--- a/lib/vagrant-ovirt4/action.rb
+++ b/lib/vagrant-ovirt4/action.rb
@@ -78,6 +78,7 @@ module VagrantPlugins
       # state is expected to be put into the `:machine_state_id` key.
       def self.action_read_state
         Vagrant::Action::Builder.new.tap do |b|
+          b.use HandleBox
           b.use ConfigValidate
           b.use ConnectOVirt
           b.use ReadState


### PR DESCRIPTION
This is required if e.g. vagrant is run in a Docker container and boxes are missing between creating and destroying vms. 
Otherwise/Currently the state will be corrupted when running `vagrant status` because the boxes are not downloaded.