### PR TITLE
Add disk resize functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Vagrant.configure("2") do |config|
     ovirt.cluster = 'Default'
     ovirt.template = 'Vagrant-Centos7-test'
     ovirt.console = 'vnc'
+    ovirt.disk_size = '15 GB' # only growing is supported. works the same way as below memory settings
     ovirt.memory_size = '1 GiB' #see https://github.com/dominikh/filesize for usage
     ovirt.memory_guaranteed = '256 MB' #see https://github.com/dominikh/filesize for usage
     ovirt.cpu_cores = 2

--- a/lib/vagrant-ovirt4/action.rb
+++ b/lib/vagrant-ovirt4/action.rb
@@ -27,7 +27,7 @@ module VagrantPlugins
             if env[:machine_state_id] == :not_created
               b2.use SetNameOfDomain
               b2.use CreateVM
-              #b2.use ResizeDisk
+              b2.use ResizeDisk
 
               b2.use Provision
               b2.use CreateNetworkInterfaces
@@ -220,6 +220,7 @@ module VagrantPlugins
       autoload :IsRunning, action_root.join("is_running")
       autoload :ReadSSHInfo, action_root.join("read_ssh_info")
       autoload :ReadState, action_root.join("read_state")
+      autoload :ResizeDisk, action_root.join("resize_disk")
       autoload :SetNameOfDomain, action_root.join("set_name_of_domain")
       autoload :SnapshotDelete, action_root.join("snapshot_delete")
       autoload :SnapshotList, action_root.join("snapshot_list")

--- a/lib/vagrant-ovirt4/action/create_vm.rb
+++ b/lib/vagrant-ovirt4/action/create_vm.rb
@@ -27,6 +27,7 @@ module VagrantPlugins
           env[:ui].info(" -- Console Type:  #{config.console}")
           env[:ui].info(" -- BIOS Serial:   #{config.bios_serial}")
           env[:ui].info(" -- Optimized For: #{config.optimized_for}")
+          env[:ui].info(" -- Disk:          #{Filesize.from("#{config.disk_size} B").to_f('GB').to_i} GB") unless config.disk_size.nil?
           env[:ui].info(" -- Memory:        ")
           env[:ui].info(" ---- Memory:      #{Filesize.from("#{config.memory_size} B").to_f('MB').to_i} MB")
           env[:ui].info(" ---- Maximum:     #{Filesize.from("#{config.memory_maximum} B").to_f('MB').to_i} MB")

--- a/lib/vagrant-ovirt4/config.rb
+++ b/lib/vagrant-ovirt4/config.rb
@@ -11,6 +11,7 @@ module VagrantPlugins
       attr_accessor :password
       attr_accessor :insecure
       attr_accessor :debug
+      attr_accessor :disk_size
       attr_accessor :filtered_api
       attr_accessor :cpu_cores
       attr_accessor :cpu_sockets
@@ -33,6 +34,7 @@ module VagrantPlugins
         @password          = UNSET_VALUE
         @insecure          = UNSET_VALUE
         @debug             = UNSET_VALUE
+        @disk_size         = UNSET_VALUE
         @filtered_api      = UNSET_VALUE
         @cpu_cores         = UNSET_VALUE
         @cpu_sockets       = UNSET_VALUE
@@ -57,6 +59,7 @@ module VagrantPlugins
         @password = nil if @password == UNSET_VALUE
         @insecure = false if @insecure == UNSET_VALUE
         @debug = false if @debug == UNSET_VALUE
+        @disk_size = nil if @disk_size == UNSET_VALUE
         @filtered_api = false if @filtered_api == UNSET_VALUE
         @cpu_cores = 1 if @cpu_cores == UNSET_VALUE
         @cpu_sockets = 1 if @cpu_sockets == UNSET_VALUE
@@ -79,6 +82,14 @@ module VagrantPlugins
 
         unless affinity.nil?
           raise "Invalid affinity. Must be one of #{OvirtSDK4::VmAffinity.constants.map { |s| "'#{s.downcase}'" }.join(' ')}" unless OvirtSDK4::VmAffinity.constants.include? affinity.upcase.to_sym
+        end
+
+        unless disk_size.nil?
+          begin
+            @disk_size = Filesize.from(@disk_size).to_f('B').to_i
+          rescue ArgumentError
+            raise "Not able to parse 'disk_size'. Please verify and check again."
+          end
         end
 
         begin

--- a/lib/vagrant-ovirt4/errors.rb
+++ b/lib/vagrant-ovirt4/errors.rb
@@ -47,6 +47,10 @@ module VagrantPlugins
         error_key(:remove_snapshot_error)
       end
 
+      class UpdateVolumeError < VagrantOVirtError
+        error_key(:resize_disk_error)
+      end
+
       class RemoveVMError < VagrantOVirtError
         error_key(:remove_vm_error)
       end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -14,6 +14,8 @@ en:
       VM is currently powering up. Please run `vagrant halt` to abort or wait until its status is 'up'.
     wait_for_ready_vm: |-
       Waiting for VM to become "ready" to start...
+    wait_for_ready_volume: |-
+      Waiting for disk resize to finish...
     error_recovering: |-
       An error occured. Recovering..
     waiting_for_ip: |-
@@ -78,3 +80,5 @@ en:
         Snapshot with id %{id} is the active snapshot which cannot be removed.
       remove_snapshot_error: |-
         Snapshot with id %{id} Could not be removed. Details: %{error_message}.
+      resize_disk_error: |-
+        Disk resize failed. oVirt error message was '%{error_message}'


### PR DESCRIPTION
Tested with Ubuntu cloud images. Configurable the same way as memory.
Backend only supports growing the disk so if configured with too small
size fails with: "Cannot edit Virtual Disk. New disk size must be larger
than the current disk size."