### PR TITLE
Enable rsync to work with windows guests

### DIFF
--- a/lib/vagrant-ovirt4/action/sync_folders.rb
+++ b/lib/vagrant-ovirt4/action/sync_folders.rb
@@ -19,6 +19,9 @@ module VagrantPlugins
             next if data[:disabled]
             hostpath  = File.expand_path(data[:hostpath], env[:root_path])
             guestpath = data[:guestpath]
+            if env[:machine].config.vm.guest = :windows
+              guestpath = guestpath.gsub(/^(\/)/, "/cygdrive/c/")
+            end
 
             # Make sure there is a trailing slash on the host path to avoid creating an additional directory with rsync
             hostpath = "#{hostpath}/" if hostpath !~ /\/$/

--- a/lib/vagrant-ovirt4/action/sync_folders.rb
+++ b/lib/vagrant-ovirt4/action/sync_folders.rb
@@ -19,7 +19,7 @@ module VagrantPlugins
             next if data[:disabled]
             hostpath  = File.expand_path(data[:hostpath], env[:root_path])
             guestpath = data[:guestpath]
-            if env[:machine].config.vm.guest = :windows
+            if env[:machine].config.vm.guest == :windows
               guestpath = guestpath.gsub(/^(\/)/, "/cygdrive/c/")
             end
 


### PR DESCRIPTION
Windows rsync always expects cygwin drive naming -- this is required to work with Windows guests.