### PR TITLE
Give guests a chance to shutdown gracefully

### DIFF
--- a/lib/vagrant-ovirt4/action/halt_vm.rb
+++ b/lib/vagrant-ovirt4/action/halt_vm.rb
@@ -12,6 +12,13 @@ module VagrantPlugins
         def call(env)
           env[:ui].info(I18n.t("vagrant_ovirt4.halt_vm"))
 
+          # Halt via OS capability
+          if env[:machine].guest.capability?(:halt)
+            env[:machine].guest.capability(:halt)
+          end
+          # Give the VM a chance to shutdown gracefully..."
+          sleep 10
+
           machine = env[:vms_service].vm_service(env[:machine].id)
           machine.stop rescue nil #todo dont rescue
 


### PR DESCRIPTION
Currently Halt pulls the plug with a poweroff. I didn't notice the issue until provisioning a Windows VM, which means it always boots into the prompt for safe recovery mode. This is a simple method for giving the VM 10 seconds to shutdown before pulling the plug. This could be improved later by polling for the OS shutdown to skip any extra waiting.