### PR TITLE
Add support for network interfaces named by biosdevname

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Vagrant.configure("2") do |config|
     :ovirt__network_name => 'ovirtmgmt' #DHCP
     # Static configuration
     #:ovirt__ip => '192.168.2.198', :ovirt__network_name => 'ovirtmgmt', :ovirt__gateway => '192.168.2.125', :ovirt__netmask => '255.255.0.0', :ovirt__dns_servers => '192.168.2.1', :ovirt__dns_search => 'test.local'
+    # Static configuration with biosdevname naming interfaces in format ensX, where X starts from 3
+    #:ovirt__ip => '192.168.2.198', :ovirt__network_name => 'ovirtmgmt', :ovirt__gateway => '192.168.2.125', :ovirt__netmask => '255.255.0.0', :ovirt__dns_servers => '192.168.2.1', :ovirt__dns_search => 'test.local', :ovirt__biosdevname => true
 
   config.vm.provider :ovirt4 do |ovirt|
     ovirt.url = 'https://server/ovirt-engine/api'

--- a/README.md
+++ b/README.md
@@ -63,8 +63,12 @@ Vagrant.configure("2") do |config|
     :ovirt__network_name => 'ovirtmgmt' #DHCP
     # Static configuration
     #:ovirt__ip => '192.168.2.198', :ovirt__network_name => 'ovirtmgmt', :ovirt__gateway => '192.168.2.125', :ovirt__netmask => '255.255.0.0', :ovirt__dns_servers => '192.168.2.1', :ovirt__dns_search => 'test.local'
-    # Static configuration with biosdevname naming interfaces in format ensX, where X starts from 3
-    #:ovirt__ip => '192.168.2.198', :ovirt__network_name => 'ovirtmgmt', :ovirt__gateway => '192.168.2.125', :ovirt__netmask => '255.255.0.0', :ovirt__dns_servers => '192.168.2.1', :ovirt__dns_search => 'test.local', :ovirt__biosdevname => true
+    # Static configuration with biosdevname. Guest OS assigns interface names (ens3, em1 or something else). ovirt__interface_name has to match that name.
+    #:ovirt__ip => '192.168.2.198', :ovirt__network_name => 'ovirtmgmt', :ovirt__gateway => '192.168.2.125', :ovirt__netmask => '255.255.0.0', :ovirt__dns_servers => '192.168.2.1', :ovirt__dns_search => 'test.local', :ovirt__interface_name => 'ens3'
+
+#  configure additional interface
+#  config.vm.network :private_network,
+#    :ovirt__ip => '192.168.2.199', :ovirt__network_name => 'ovirtmgmt', :ovirt__netmask => '255.255.0.0', :ovirt__interface_name => 'ens4'
 
   config.vm.provider :ovirt4 do |ovirt|
     ovirt.url = 'https://server/ovirt-engine/api'

--- a/lib/vagrant-ovirt4/action/start_vm.rb
+++ b/lib/vagrant-ovirt4/action/start_vm.rb
@@ -46,9 +46,16 @@ module VagrantPlugins
           (0...configured_ifaces_options.length()).each do |iface_index|
             iface_options = configured_ifaces_options[iface_index]
 
+            if iface_options[:biosdevname] then
+              prefix = 'ens'
+              iface_index = iface_index + 3
+            else
+              prefix = 'eth'
+            end
+
             if iface_options[:ip] then
               nic_configuration = {
-                name: "eth#{iface_index}",
+                name: "#{prefix}#{iface_index}",
                 on_boot: true,
                 boot_protocol: OvirtSDK4::BootProtocol::STATIC,
                 ip: {
@@ -60,7 +67,7 @@ module VagrantPlugins
               }
             else
               nic_configuration = {
-                name: "eth#{iface_index}",
+                name: "#{prefix}#{iface_index}",
                 on_boot: true,
                 boot_protocol: OvirtSDK4::BootProtocol::DHCP,
               }

--- a/lib/vagrant-ovirt4/action/start_vm.rb
+++ b/lib/vagrant-ovirt4/action/start_vm.rb
@@ -46,16 +46,15 @@ module VagrantPlugins
           (0...configured_ifaces_options.length()).each do |iface_index|
             iface_options = configured_ifaces_options[iface_index]
 
-            if iface_options[:biosdevname] then
-              prefix = 'ens'
-              iface_index = iface_index + 3
+            if iface_options[:interface_name] != nil then
+              iface_name = iface_options[:interface_name]
             else
-              prefix = 'eth'
+              iface_name = "eth#{iface_index}"
             end
 
             if iface_options[:ip] then
               nic_configuration = {
-                name: "#{prefix}#{iface_index}",
+                name: iface_name,
                 on_boot: true,
                 boot_protocol: OvirtSDK4::BootProtocol::STATIC,
                 ip: {
@@ -67,7 +66,7 @@ module VagrantPlugins
               }
             else
               nic_configuration = {
-                name: "#{prefix}#{iface_index}",
+                name: iface_name,
                 on_boot: true,
                 boot_protocol: OvirtSDK4::BootProtocol::DHCP,
               }


### PR DESCRIPTION
Currently using static network configuration doesn't work with VM images using biosdevname because the static configuration gets always created for ethX.

Not a very generic solution. I guess there's no way to detect how the interfaces get named but at least this makes it possible to set static IP's on newer Ubuntu releases. Tested with Ubuntu 18.04 where interfaces start from ens3.