### PR TITLE
In case graceful shutdown failed, fallback to stopping VM immediately

### DIFF
--- a/lib/vagrant-ovirt4/action/halt_vm.rb
+++ b/lib/vagrant-ovirt4/action/halt_vm.rb
@@ -13,11 +13,15 @@ module VagrantPlugins
           env[:ui].info(I18n.t("vagrant_ovirt4.halt_vm"))
 
           # Halt via OS capability
-          if env[:machine].guest.capability?(:halt)
-            env[:machine].guest.capability(:halt)
+          begin
+            if env[:machine].guest.capability?(:halt)
+              env[:machine].guest.capability(:halt)
+              # Give the VM a chance to shutdown gracefully..."
+              sleep 10
+            end
+          rescue
+            env[:ui].info("Failed to shutdown guest gracefully.")
           end
-          # Give the VM a chance to shutdown gracefully..."
-          sleep 10
 
           machine = env[:vms_service].vm_service(env[:machine].id)
           machine.stop rescue nil #todo dont rescue


### PR DESCRIPTION
Checking capabilities fails if guest has crashed or failed to boot in the first
place. In that case vagrant destroy fails to do it's job:

==> default: Halting VM...
ERROR warden: Error occurred: Guest-specific operations were attempted on a machine that is not
ready for guest communication. This should not happen and a bug
should be reported.