### PR TITLE
fix for waiting indefinitely for an ip when deploying on ovirt 4.4

### DIFF
--- a/lib/vagrant-ovirt4/action/wait_till_up.rb
+++ b/lib/vagrant-ovirt4/action/wait_till_up.rb
@@ -57,7 +57,7 @@ module VagrantPlugins
 
               nics_service = server.nics_service
               nics = nics_service.list
-              ip_addr = nics.collect { |nic_attachment| env[:connection].follow_link(nic_attachment).reported_devices.collect { |dev| dev.ips.collect { |ip| ip.address if ip.version == 'v4' } unless dev.ips.nil? } }.flatten.reject { |ip| ip.nil? }.first rescue nil
+              ip_addr = nics.collect { |nic_attachment| env[:connection].follow_link(nic_attachment.reported_devices).collect { |dev| dev.ips.collect { |ip| ip.address if ip.version == 'v4' } unless dev.ips.nil? } }.flatten.reject { |ip| ip.nil? }.first rescue nil
               unless ip_addr.nil?
                 env[:ui].info("Got IP: #{ip_addr}")
                 # Check if SSH-Server is up


### PR DESCRIPTION
fix for issue #120 

I'm by no means a ruby programmer, but this works for me. The old code tried to collect the ip addresses from the original nic object, not from the reported_devices. I guess, there was an ever so slight change in the ruby sdk or the API. 

Tested with ovirt 4.4.2.6-1.el8 and ubuntu 20.04 WSL on Windows 10 20H2