### PR TITLE
fix for erroneous rsync and state error due to missing ip address

### DIFF
--- a/lib/vagrant-ovirt4/action/read_ssh_info.rb
+++ b/lib/vagrant-ovirt4/action/read_ssh_info.rb
@@ -36,7 +36,7 @@ module VagrantPlugins
 
           nics_service = server.nics_service
           nics = nics_service.list
-          ip_addr = nics.collect { |nic_attachment| env[:connection].follow_link(nic_attachment).reported_devices.collect { |dev| dev.ips.collect { |ip| ip.address if ip.version == 'v4' } unless dev.ips.nil? } }.flatten.reject { |ip| ip.nil? }.first rescue nil
+          ip_addr = nics.collect { |nic_attachment| env[:connection].follow_link(nic_attachment.reported_devices).collect { |dev| dev.ips.collect { |ip| ip.address if ip.version == 'v4' } unless dev.ips.nil? } }.flatten.reject { |ip| ip.nil? }.first rescue nil
 
           # Return the info
           # TODO: Some info should be configurable in Vagrantfile

--- a/lib/vagrant-ovirt4/action/read_state.rb
+++ b/lib/vagrant-ovirt4/action/read_state.rb
@@ -33,7 +33,7 @@ module VagrantPlugins
           end
           nics_service = server.nics_service
           nics = nics_service.list
-          ip_addr = nics.collect { |nic_attachment| env[:connection].follow_link(nic_attachment).reported_devices.collect { |dev| dev.ips.collect { |ip| ip.address if ip.version == 'v4' } unless dev.ips.nil? } }.flatten.reject { |ip| ip.nil? }.first rescue nil
+          ip_addr = nics.collect { |nic_attachment| env[:connection].follow_link(nic_attachment.reported_devices).collect { |dev| dev.ips.collect { |ip| ip.address if ip.version == 'v4' } unless dev.ips.nil? } }.flatten.reject { |ip| ip.nil? }.first rescue nil
           unless ip_addr.nil?
             env[:ip_address] = ip_addr
             @logger.debug("Got output #{env[:ip_address]}")


### PR DESCRIPTION
Another fix for #120 

The same code fragment, parsing the ip address (see #121), is also used reading the ssh_info and the state. This caused the rsync command to fail, as it used the ip address from ssh_info as a hostname. 

A more maintenance-friendly approach for future use would be to pull this code fragment into its own little class/module or whatever it is called in ruby :). But for now, I try to get everything into working order before starting any tidy-up actions.

Again tested on ovirt 4.4.2.6-1.el8 cluster with Ubuntu 20.04 WSL on Windows 10 20H2

edit:
One thing I forgot to mention: the rsync tasks asks for a password, which seems rather odd to me. I assumed that vagrant will use the identity key for doing communication. But I'm quite new to vagrant so maybe this is normal!? See als the attached log of `vagrant up`

log:

```
❯ vagrant up
Bringing machine 'default' up with 'ovirt4' provider...
==> default: Creating VM with the following settings...
==> default:  -- Name:          centos-dev
==> default:  -- Cluster:       Intel_Cluster
==> default:  -- Template:      centos-8
==> default:  -- Console Type:  spice
==> default:  -- BIOS Serial:
==> default:  -- Optimized For:
==> default:  -- Description:
==> default:  -- Comment:
==> default:  -- Memory:
==> default:  ---- Memory:      768 MB
==> default:  ---- Maximum:     768 MB
==> default:  ---- Guaranteed:  768 MB
==> default:  -- Cpu:
==> default:  ---- Cores:       1
==> default:  ---- Sockets:     1
==> default:  ---- Threads:     2
==> default:  -- Cloud-Init:    true
==> default: Waiting for VM to become "ready" to start...
==> default: Starting VM.
==> default: Test
==> default: Got IP: 10.20.190.45
==> default: Got IP: 10.20.190.45
==> default: Got IP: 10.20.190.45
==> default: Got IP: 10.20.190.45
==> default: Got IP: 10.20.190.45
==> default: Got IP: 10.20.190.45
==> default: Got IP: 10.20.190.45
==> default: Got IP: 10.20.190.45
==> default: Got IP: 10.20.190.45
==> default: Machine is booted and ready for use!
==> default: Rsyncing folder: /mnt/c/Users/SES/Source/ansible-icinga/ => /vagrant
vagrant@10.20.190.45's password:
==> default: Setting hostname...
    default:
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default:
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
```