### PR TITLE
vagrant destroy only calls halt if vm is up

### DIFF
--- a/lib/vagrant-ovirt4/action.rb
+++ b/lib/vagrant-ovirt4/action.rb
@@ -54,8 +54,8 @@ module VagrantPlugins
 
             b2.use ConnectOVirt
             b2.use ProvisionerCleanup, :before if defined?(ProvisionerCleanup)
-            b2.use HaltVM
-            b2.use WaitTillDown
+            b2.use HaltVM unless env[:machine].state.id == :down
+            b2.use WaitTillDown unless env[:machine].state.id == :down
             b2.use DestroyVM
             b2.use DisconnectOVirt
           end


### PR DESCRIPTION
Enhancement/Fix for #124 

Upon calling `vagrant destroy` the `halt` action is executed regardless of the virtual machines state. This pull-request changes this behavior similar to the one found in [vagrant-vmware-esxi](https://github.com/josenk/vagrant-vmware-esxi), where the action is only executed if the vm is not in the `down` state.

**Test Case 1 - create a vm and then destroy it**
```
❯ vagrant up
Bringing machine 'default' up with 'ovirt4' provider...
==> default: Creating VM with the following settings...
==> default:  -- Name:          centos-dev
==> default:  -- Cluster:       Intel_Cluster
==> default:  -- Template:      centos-8
==> default:  -- Console Type:  spice
==> default:  -- BIOS Serial:
==> default:  -- Optimized For:
==> default:  -- Description:
==> default:  -- Comment:
==> default:  -- Memory:
==> default:  ---- Memory:      768 MB
==> default:  ---- Maximum:     768 MB
==> default:  ---- Guaranteed:  768 MB
==> default:  -- Cpu:
==> default:  ---- Cores:       1
==> default:  ---- Sockets:     1
==> default:  ---- Threads:     2
==> default:  -- Cloud-Init:    true
==> default: Waiting for VM to become "ready" to start...
==> default: Starting VM.
==> default: Waiting for VM to get an IP address...
==> default: Got IP: 10.20.190.5
==> default: Got IP: 10.20.190.5
==> default: Got IP: 10.20.190.5
==> default: Got IP: 10.20.190.5
==> default: Got IP: 10.20.190.5
==> default: Got IP: 10.20.190.5
==> default: Got IP: 10.20.190.5
==> default: Machine is booted and ready for use!
==> default: Rsyncing folder: /mnt/c/Users/SES/Source/ansible-icinga/ => /vagrant
==> default: Setting hostname...
    default:
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default:
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
❯ vagrant destroy
==> default: Halting VM...
==> default: Waiting for VM to shutdown...
==> default: Removing VM...
```

**Test Case 2 - create a vm, halt and finally destroy it**
```
❯ vagrant up
Bringing machine 'default' up with 'ovirt4' provider...
==> default: Creating VM with the following settings...
==> default:  -- Name:          centos-dev
==> default:  -- Cluster:       Intel_Cluster
==> default:  -- Template:      centos-8
==> default:  -- Console Type:  spice
==> default:  -- BIOS Serial:
==> default:  -- Optimized For:
==> default:  -- Description:
==> default:  -- Comment:
==> default:  -- Memory:
==> default:  ---- Memory:      768 MB
==> default:  ---- Maximum:     768 MB
==> default:  ---- Guaranteed:  768 MB
==> default:  -- Cpu:
==> default:  ---- Cores:       1
==> default:  ---- Sockets:     1
==> default:  ---- Threads:     2
==> default:  -- Cloud-Init:    true
==> default: Waiting for VM to become "ready" to start...
==> default: Starting VM.
==> default: Waiting for VM to get an IP address...
==> default: Got IP: 10.20.190.4
==> default: Got IP: 10.20.190.4
==> default: Got IP: 10.20.190.4
==> default: Got IP: 10.20.190.4
==> default: Got IP: 10.20.190.4
==> default: Got IP: 10.20.190.4
==> default: Got IP: 10.20.190.4
==> default: Got IP: 10.20.190.4
==> default: Machine is booted and ready for use!
==> default: Rsyncing folder: /mnt/c/Users/SES/Source/ansible-icinga/ => /vagrant
==> default: Setting hostname...
    default:
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default:
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
❯ vagrant halt
==> default: Halting VM...
==> default: Waiting for VM to shutdown...
❯ vagrant destroy
==> default: Removing VM...
```

**Test Case 3 - create a vm, halt it via ovirt web interface and then destroy it** 
```
❯ vagrant up
Bringing machine 'default' up with 'ovirt4' provider...
==> default: Creating VM with the following settings...
==> default:  -- Name:          centos-dev
==> default:  -- Cluster:       Intel_Cluster
==> default:  -- Template:      centos-8
==> default:  -- Console Type:  spice
==> default:  -- BIOS Serial:
==> default:  -- Optimized For:
==> default:  -- Description:
==> default:  -- Comment:
==> default:  -- Memory:
==> default:  ---- Memory:      768 MB
==> default:  ---- Maximum:     768 MB
==> default:  ---- Guaranteed:  768 MB
==> default:  -- Cpu:
==> default:  ---- Cores:       1
==> default:  ---- Sockets:     1
==> default:  ---- Threads:     2
==> default:  -- Cloud-Init:    true
==> default: Waiting for VM to become "ready" to start...
==> default: Starting VM.
==> default: Waiting for VM to get an IP address...
==> default: Got IP: 10.20.190.10
==> default: Got IP: 10.20.190.10
==> default: Got IP: 10.20.190.10
==> default: Got IP: 10.20.190.10
==> default: Got IP: 10.20.190.10
==> default: Got IP: 10.20.190.10
==> default: Got IP: 10.20.190.10
==> default: Got IP: 10.20.190.10
==> default: Machine is booted and ready for use!
==> default: Rsyncing folder: /mnt/c/Users/SES/Source/ansible-icinga/ => /vagrant
==> default: Setting hostname...
    default:
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default:
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
❯ vagrant destroy
==> default: Removing VM...
```

All tests OK on ovirt 4.4.2.6-1.el8 and Ubuntu 20.04 WSL on Windows 20H2