### PR TITLE
fixed inconsistent usages of memory units (MB/MiB and GB/GiB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ Vagrant.configure("2") do |config|
     ovirt.cluster = 'Default'
     ovirt.template = 'Vagrant-Centos7-test'
     ovirt.console = 'vnc'
-    ovirt.disk_size = '15 GB' # only growing is supported. works the same way as below memory settings
+    ovirt.disk_size = '15 GiB' # only growing is supported. works the same way as below memory settings
     ovirt.memory_size = '1 GiB' #see https://github.com/dominikh/filesize for usage
-    ovirt.memory_guaranteed = '256 MB' #see https://github.com/dominikh/filesize for usage
+    ovirt.memory_guaranteed = '256 MiB' #see https://github.com/dominikh/filesize for usage
     ovirt.cpu_cores = 2
     ovirt.cpu_sockets = 2
     ovirt.cpu_threads = 2

--- a/lib/vagrant-ovirt4/action/create_vm.rb
+++ b/lib/vagrant-ovirt4/action/create_vm.rb
@@ -29,15 +29,15 @@ module VagrantPlugins
           env[:ui].info(" -- Optimized For: #{config.optimized_for}")
           env[:ui].info(" -- Description:   #{config.description}")
           env[:ui].info(" -- Comment:       #{config.comment}")
-          env[:ui].info(" -- Disk:          #{Filesize.from("#{config.disk_size} B").to_f('GB').to_i} GB") unless config.disk_size.nil?
+          env[:ui].info(" -- Disk:          #{Filesize.from("#{config.disk_size} B").to_f('GiB').to_i} GiB") unless config.disk_size.nil?
           env[:ui].info(" -- Additional Disks:") unless config.disks.empty?
           config.disks.each do |disk|
-            env[:ui].info(" ---- name=#{disk[:name]} size=#{Filesize.from("#{disk[:size]} B").to_f('GB').to_i} GB")
+            env[:ui].info(" ---- name=#{disk[:name]} size=#{Filesize.from("#{disk[:size]} B").to_f('GiB').to_i} GiB")
           end
           env[:ui].info(" -- Memory:        ")
-          env[:ui].info(" ---- Memory:      #{Filesize.from("#{config.memory_size} B").to_f('MB').to_i} MB")
-          env[:ui].info(" ---- Maximum:     #{Filesize.from("#{config.memory_maximum} B").to_f('MB').to_i} MB")
-          env[:ui].info(" ---- Guaranteed:  #{Filesize.from("#{config.memory_guaranteed} B").to_f('MB').to_i} MB")
+          env[:ui].info(" ---- Memory:      #{Filesize.from("#{config.memory_size} B").to_f('MiB').to_i} MiB")
+          env[:ui].info(" ---- Maximum:     #{Filesize.from("#{config.memory_maximum} B").to_f('MiB').to_i} MiB")
+          env[:ui].info(" ---- Guaranteed:  #{Filesize.from("#{config.memory_guaranteed} B").to_f('MiB').to_i} MiB")
           env[:ui].info(" -- Cpu:           ")
           env[:ui].info(" ---- Cores:       #{config.cpu_cores}")
           env[:ui].info(" ---- Sockets:     #{config.cpu_sockets}")

--- a/lib/vagrant-ovirt4/config.rb
+++ b/lib/vagrant-ovirt4/config.rb
@@ -98,7 +98,7 @@ module VagrantPlugins
         @cpu_threads = 1 if @cpu_threads == UNSET_VALUE
         @cluster = nil if @cluster == UNSET_VALUE
         @console = nil if @console == UNSET_VALUE
-        @memory_size = '256 MB' if @memory_size == UNSET_VALUE
+        @memory_size = '256 MiB' if @memory_size == UNSET_VALUE
         @memory_maximum = @memory_size if @memory_maximum == UNSET_VALUE
         @memory_guaranteed = @memory_size if @memory_guaranteed == UNSET_VALUE
         @template = nil if @template == UNSET_VALUE

--- a/spec/vagrant-ovirt4/config_spec.rb
+++ b/spec/vagrant-ovirt4/config_spec.rb
@@ -68,13 +68,13 @@ describe VagrantPlugins::OVirtProvider::Config do
     [:memory_size, :memory_maximum, :memory_guaranteed].each do |attribute|
 
       it "should not default #{attribute} if overridden" do
-        instance.send("#{attribute}=".to_sym, "512 MB")
+        instance.send("#{attribute}=".to_sym, "512 MiB")
         instance.finalize!
         instance.send(attribute).should == 512000000
       end
 
       it "should convert the value" do
-        instance.send("#{attribute}=".to_sym, "1 GB")
+        instance.send("#{attribute}=".to_sym, "1 GiB")
         instance.finalize!
         instance.send(attribute).should == 1000000000
       end


### PR DESCRIPTION
partly fixes #126 

Consolidated memory units to `MiB` and `GiB`. Now output from `vagrant` and `ovirt` should match up (i.e. 4096 MiB is shown as 4096MB at the web dashboard)

Tested OK with ovirt 4.4.2.6-1.el8 on Ubuntu 20.04 WSL on Windows 20H2

Log: 
```
❯ vagrant up
Bringing machine 'default' up with 'ovirt4' provider...
==> default: Creating VM with the following settings...
==> default:  -- Name:          backup-monitoring
==> default:  -- Cluster:       Intel_Cluster
==> default:  -- Template:      centos-8-stream
==> default:  -- Console Type:  vnc
==> default:  -- BIOS Serial:
==> default:  -- Optimized For:
==> default:  -- Description:
==> default:  -- Comment:
==> default:  -- Memory:
==> default:  ---- Memory:      4096 MiB
==> default:  ---- Maximum:     4096 MiB
==> default:  ---- Guaranteed:  4096 MiB
==> default:  -- Cpu:
==> default:  ---- Cores:       2
==> default:  ---- Sockets:     1
==> default:  ---- Threads:     2
==> default:  -- Cloud-Init:    true
==> default: Waiting for VM to become "ready" to start...
==> default: Starting VM.
==> default: Waiting for VM to get an IP address...
==> default: Got IP: 10.20.182.6
==> default: Got IP: 10.20.182.6
==> default: Got IP: 10.20.182.6
==> default: Got IP: 10.20.182.6
==> default: Got IP: 10.20.182.6
==> default: Got IP: 10.20.182.6
==> default: Got IP: 10.20.182.6
==> default: Got IP: 10.20.182.6
==> default: Machine is booted and ready for use!
    default:
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default:
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Rsyncing folder: /mnt/c/Users/SES/Source/ansible-backup-monitoring/vagrant/ => /vagrant
==> default: Setting hostname...
```