### PR TITLE
fixed double disconnect on reload due to use of with_ovirt

### DIFF
--- a/lib/vagrant-ovirt4/action.rb
+++ b/lib/vagrant-ovirt4/action.rb
@@ -168,7 +168,7 @@ module VagrantPlugins
       end
 
       def self.action_reload
-        with_ovirt do |env, b|
+        Vagrant::Action::Builder.new.tap do |b|
           b.use action_halt
           b.use action_up
         end


### PR DESCRIPTION
fixes #129 

The reuse of existing actions in combination with the `with_ovirt` helper method caused a double-call to disconnect. This caused vagrant to error out and clean up the vm, despite completing the task successfully. 

Tested OK on ovirt 4.4.2.6-1.el8 cluster with Ubuntu 20.04 WSL on Windows 20H2

Log:
´´´
❯ vagrant reload
==> default: Halting VM...
==> default: Waiting for VM to shutdown...
==> default: Starting VM.
==> default: Waiting for VM to get an IP address...
==> default: Got IP: 10.20.182.6
==> default: Got IP: 10.20.182.6
==> default: Got IP: 10.20.182.6
==> default: Got IP: 10.20.182.6
==> default: Got IP: 10.20.182.6
==> default: Got IP: 10.20.182.6
==> default: Got IP: 10.20.182.6
==> default: Got IP: 10.20.182.6
==> default: Got IP: 10.20.182.6
==> default: Machine is booted and ready for use!
==> default: Rsyncing folder: /mnt/c/Users/SES/Source/ansible-backup-monitoring/vagrant/ => /vagrant
❯ vagrant status
Current machine states:

default                   up (ovirt4)

The instance is running. Use `vagrant halt` to stop it.
´´´