### PR TITLE
fixed double disconnect due to action_up used in combination wth with with_ovirt

### DIFF
--- a/lib/vagrant-ovirt4/action.rb
+++ b/lib/vagrant-ovirt4/action.rb
@@ -201,7 +201,8 @@ module VagrantPlugins
             b.use MessageNotSuspended
             next
           end
-          b.use action_up
+          b.use StartVM
+          b.use WaitTillUp
         end
       end
 


### PR DESCRIPTION
fixes #131 

Pretty much the same as for #130. In this case I decided to replace the call to `action_up` with a dedicated call to `StartVM` and `WaitTillUp` with the pure intention of not running folder synchronization. In my opinion, running folder sync on resume will not be expected in most cases and might even result in additional confusion.

Tested OK on ovirt 4.4.2.6-1.el8 cluster with Ubuntu 20.04 WSL on Windows 20H2

Log:
```
❯ vagrant suspend
==> default: Suspending VM...
==> default: Waiting for VM to suspend...
❯ vagrant resume
==> default: Starting VM.
==> default: Waiting for VM to get an IP address...
==> default: Got IP: 10.20.182.6
==> default: Got IP: 10.20.182.6
==> default: Machine is booted and ready for use!
``` 