### PR TITLE
list only snapshots for vm's defined in the environment

### DIFF
--- a/lib/vagrant-ovirt4/action/snapshot_list.rb
+++ b/lib/vagrant-ovirt4/action/snapshot_list.rb
@@ -14,34 +14,30 @@ module VagrantPlugins
 
           system_service = env[:connection].system_service
 
-          # Find all the virtual machines and store the id and name in a
+          #Find all storage domains and store the id and name in a
           # hash, so that looking them up later will be faster:
-          vms_map = Hash[env[:vms_service].list.map { |vm| [vm.id, vm.name] }]
-          
-          # Same for storage domains:
           sds_service = system_service.storage_domains_service
           sds_map = Hash[sds_service.list.map { |sd| [sd.id, sd.name] }]
           
           # For each virtual machine find its snapshots, then for each snapshot
           # find its disks:
           xs = [['id', 'description', 'date']]
-          vms_map.each do |vm_id, vm_name|
-            vm_service = env[:vms_service].vm_service(vm_id)
-            snaps_service = vm_service.snapshots_service
-            snaps_map = Hash[snaps_service.list.map { |snap| [snap.id, { description: snap.description, date: snap.date }] }]
-            snaps_map.each do |snap_id, metadata|
-              snap_description = metadata[:description]
-              snap_date = metadata[:date]
-              snap_service = snaps_service.snapshot_service(snap_id)
-              disks_service = snap_service.disks_service
-              disks_service.list.each do |disk|
-                next unless disk.storage_domains.any?
-                sd_id = disk.storage_domains.first.id
-                sd_name = sds_map[sd_id]
-                xs.push([snap_id, snap_description, snap_date.to_s])
-              end
+          vm_service = env[:vms_service].vm_service(env[:machine].id)
+          snaps_service = vm_service.snapshots_service
+          snaps_map = Hash[snaps_service.list.map { |snap| [snap.id, { description: snap.description, date: snap.date }] }]
+          snaps_map.each do |snap_id, metadata|
+            snap_description = metadata[:description]
+            snap_date = metadata[:date]
+            snap_service = snaps_service.snapshot_service(snap_id)
+            disks_service = snap_service.disks_service
+            disks_service.list.each do |disk|
+              next unless disk.storage_domains.any?
+              sd_id = disk.storage_domains.first.id
+              sd_name = sds_map[sd_id]
+              xs.push([snap_id, snap_description, snap_date.to_s])
             end
           end
+
           widths = xs.transpose.map { |column_arr| column_arr.map(&:size).max }
           env[:machine_snapshot_list] = 
               xs.map { |row_arr| 


### PR DESCRIPTION
fixes #133 

I figured we don't need to enumerate all vms in the cluster and rather use the machine ids in the environment `env` to query exactly the vm's we want.  This should also increase the performance for clusters with a lot vm's. 

I tested my fix with a Vagrantfile containing two vm's `test1` and `test2`. I tested listing snapshots for both vm's and for each vm individually.

Tested OK on ovirt 4.4.2.6-1.el8 with Ubuntu 20.40 WSL on WIndows 10 20H2

`test1` contains two snapshots `fun` and `clean`
`test2` contains one snapshot `nofun`

Logs:
```
❯ vagrant snapshot list
==> test1: Retrieving list of snapshots...
==> test1:
                                  id     description                          date
15423774-3dbf-46d8-8b4f-ec66ddc5d383             fun     2021-01-16T13:31:34+01:00
e3fe7587-89ea-4c3c-a22b-380cf48e1fdf           clean     2021-01-16T13:46:57+01:00
==> test2: Retrieving list of snapshots...
==> test2:
                                  id     description                          date
2bf7fdc1-3447-4fde-b815-bf97af4f3d67          notfun     2021-01-16T13:31:55+01:00

❯ vagrant snapshot list test2
==> test2: Retrieving list of snapshots...
==> test2:
                                  id     description                          date
2bf7fdc1-3447-4fde-b815-bf97af4f3d67          notfun     2021-01-16T13:31:55+01:00

❯ vagrant snapshot list test1
==> test1: Retrieving list of snapshots...
==> test1:
                                  id     description                          date
15423774-3dbf-46d8-8b4f-ec66ddc5d383             fun     2021-01-16T13:31:34+01:00
e3fe7587-89ea-4c3c-a22b-380cf48e1fdf           clean     2021-01-16T13:46:57+01:00
``` 