### PR TITLE
Rakefile: add RSpec task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,3 +14,7 @@ Dir.chdir(File.expand_path("../", __FILE__))
 # This installs the tasks that help with gem creation and
 # publishing.
 Bundler::GemHelper.install_tasks
+
+RSpec::Core::RakeTask.new
+
+task :default => [:spec]


### PR DESCRIPTION
and make it the default action (`task :default => [:spec]`) so that

```shell
$ rake 
```

executes tests rather than raising an error.

Note that `Rakefile` already imports `rspec/core/rake_task`; this change just instantiates the task (library).

Thanks in advance for your consideration!