### PR TITLE
Support :timeout and :timeout_connect options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[OvirtSDK4::Connection#initialize]: https://rubydoc.info/gems/ovirt-engine-sdk/OvirtSDK4%2FConnection:initialize
+
 # Vagrant oVirt v4 Provider
 
 This is a [Vagrant](http://www.vagrantup.com) 1.1+ plugin that adds an
@@ -76,6 +78,8 @@ Vagrant.configure("2") do |config|
     ovirt.password = "password"
     ovirt.insecure = true
     ovirt.debug = true
+    ovirt.timeout = 120 # seconds
+    ovirt.connect_timeout = 30 # seconds
     ovirt.filtered_api = true #see http://www.ovirt.org/develop/release-management/features/infra/user-portal-permissions/
     ovirt.cluster = 'Default'
     ovirt.vmname = 'my-vm'
@@ -120,6 +124,15 @@ end
   1. `password` => The password for the API. Required. String. No default value.
   1. `insecure` => Allow connecting to SSL sites without certificates. Optional. Bool. Default is `false`
   1. `debug` => Turn on additional log statements. Optional. Bool. Default is `false`.
+  1. `timeout` => Per [the oVirt SDK docs][OvirtSDK4::Connection#initialize],
+     "The maximun (_sic_) total time to wait for the response, in seconds. A value of
+     zero (the default) means wait for ever." Optional. Integer. Uses the
+     `OvirtSDK4::Connection` default if omitted; as of the time of writing,
+     this is `0` (i.e. wait forever).
+  1. `connect_timeout` => Per [the oVirt SDK docs][OvirtSDK4::Connection#initialize],
+     "The maximun (_sic_) time to wait for connection establishment, in
+     seconds." Optional. Integer. Uses the `OvirtSDK4::Connection` default if
+     omitted; as of the time of writing, this is `300`.
   1. `vmname` => Sets the name of the VM. Optional. String. Default is
      `config.vm.hostname`, if defined, otherwise `"vagrant"`.
     a. Is the 'name' in the Virtual Machine tab of the UI

--- a/lib/vagrant-ovirt4/action/connect_ovirt.rb
+++ b/lib/vagrant-ovirt4/action/connect_ovirt.rb
@@ -22,6 +22,8 @@ module VagrantPlugins
           conn_attr[:debug] = config.debug if config.debug
           conn_attr[:insecure] = true if config.insecure
           conn_attr[:headers] = {'Filter' => true} if config.filtered_api
+          conn_attr[:timeout] = config.timeout unless config.timeout.nil?
+          conn_attr[:connect_timeout] = config.connect_timeout unless config.connect_timeout.nil?
 
           @logger.info("Connecting to oVirt (#{config.url}) ...")
           ovirt_connection = OvirtSDK4::Connection.new(conn_attr)

--- a/lib/vagrant-ovirt4/config.rb
+++ b/lib/vagrant-ovirt4/config.rb
@@ -31,6 +31,8 @@ module VagrantPlugins
       attr_accessor :comment
       attr_accessor :vmname
       attr_accessor :disks
+      attr_accessor :timeout
+      attr_accessor :connect_timeout
 
       def initialize
         @url               = UNSET_VALUE
@@ -57,6 +59,8 @@ module VagrantPlugins
         @description       = UNSET_VALUE
         @comment           = UNSET_VALUE
         @vmname            = UNSET_VALUE
+        @timeout           = UNSET_VALUE
+        @connect_timeout   = UNSET_VALUE
         @disks             = []
 
       end
@@ -112,6 +116,8 @@ module VagrantPlugins
         @description = '' if @description == UNSET_VALUE
         @comment = '' if @comment == UNSET_VALUE
         @vmname = nil if @vmname == UNSET_VALUE
+        @timeout = nil if @timeout == UNSET_VALUE
+        @connect_timeout = nil if @connect_timeout == UNSET_VALUE
 
         unless optimized_for.nil?
           raise "Invalid 'optimized_for'. Must be one of #{OvirtSDK4::VmType.constants.map { |s| "'#{s.downcase}'" }.join(' ')}" unless OvirtSDK4::VmType.constants.include? optimized_for.upcase.to_sym
@@ -135,6 +141,24 @@ module VagrantPlugins
           @memory_guaranteed = Filesize.from(@memory_guaranteed).to_f('B').to_i
         rescue ArgumentError
           raise "Not able to parse either `memory_size` or `memory_guaranteed`. Please verify and check again."
+        end
+
+        unless timeout.nil?
+          begin
+            @timeout = Integer(@timeout)
+            raise ArgumentError if @timeout < 0
+          rescue ArgumentError, TypeError
+            raise "`timeout` argument #{@timeout.inspect} is not a valid nonnegative integer"
+          end
+        end
+
+        unless connect_timeout.nil?
+          begin
+            @connect_timeout = Integer(@connect_timeout)
+            raise ArgumentError if @connect_timeout < 0
+          rescue ArgumentError, TypeError
+            raise "`connect_timeout` argument #{@connect_timeout.inspect} is not a valid nonnegative integer"
+          end
         end
       end
 

--- a/spec/vagrant-ovirt4/config_spec.rb
+++ b/spec/vagrant-ovirt4/config_spec.rb
@@ -125,4 +125,34 @@ describe VagrantPlugins::OVirtProvider::Config do
 
   end
 
+  describe "overriding timeout defaults" do
+    [:timeout, :connect_timeout].each do |attribute|
+      [0, 6, 1_000_000, 8.10, nil].each do |value|
+        it "should accept #{value.to_s} for #{attribute}" do
+          instance.send("#{attribute}=".to_sym, value)
+          instance.finalize!
+
+          if value.nil?
+            instance.send(attribute).should be_nil
+          else
+            instance.send(attribute).should == Integer(value)
+          end
+        end
+      end
+
+      ["foo", Object.new, -100].each do |value|
+        it "should reject a value for #{attribute} outside of the defined values" do
+          expect {
+            instance.send("#{attribute}=".to_sym, value)
+            instance.finalize!
+          }.to raise_error { |error|
+            expect(error).to be_a(RuntimeError)
+            expect(error.message).to match(/nonnegative integer/)
+          }
+        end
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
to `OvirtSDK4::Connection.new` as part of the provider configuration interface.

Thanks in advance for your consideration!