### PR TITLE
Add vmname provider option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Vagrant.configure("2") do |config|
     ovirt.debug = true
     ovirt.filtered_api = true #see http://www.ovirt.org/develop/release-management/features/infra/user-portal-permissions/
     ovirt.cluster = 'Default'
+    ovirt.vmname = 'my-vm'
     ovirt.template = 'Vagrant-Centos7-test'
     ovirt.console = 'vnc'
     ovirt.disk_size = '15 GiB' # only growing is supported. works the same way as below memory settings
@@ -105,8 +106,8 @@ end
 ### Configuration options
 
 1. Vagrant specific
-  1. `config.vm.hostname` => Sets the hostname of the VM
-    a. Is the 'name' in the Virtual Machine tab of the UI
+  1. `config.vm.hostname` => Sets the hostname of the VM. Optional. String.
+     Default is `"vagrant"`.
     a. Is the 'hostname' of the VM configured by `cloud-init`
   1. `config.vm.network` => Sets the network information of the VM.
     a. Note: `:ip` => is ignored, but `:ovirt__ip` is used and merged with `:ip`
@@ -119,6 +120,9 @@ end
   1. `password` => The password for the API. Required. String. No default value.
   1. `insecure` => Allow connecting to SSL sites without certificates. Optional. Bool. Default is `false`
   1. `debug` => Turn on additional log statements. Optional. Bool. Default is `false`.
+  1. `vmname` => Sets the name of the VM. Optional. String. Default is
+     `config.vm.hostname`, if defined, otherwise `"vagrant"`.
+    a. Is the 'name' in the Virtual Machine tab of the UI
   1. `template` => The name of the template to use for creation. Required. String. No Default value.
   1. `cluster` => The name of the ovirt cluster to create within. Required. String. No Default value.
   1. `console` => The type of remote viewing protocol to use. Required. String. No Default value.

--- a/lib/vagrant-ovirt4/action/start_vm.rb
+++ b/lib/vagrant-ovirt4/action/start_vm.rb
@@ -1,4 +1,6 @@
 require 'log4r'
+require 'vagrant-ovirt4/errors'
+require 'vagrant-ovirt4/util/machine_names'
 require 'vagrant/util/scoped_hash_override'
 
 module VagrantPlugins
@@ -7,6 +9,7 @@ module VagrantPlugins
 
       # Just start the VM.
       class StartVM
+        include Util::MachineNames
         include Vagrant::Util::ScopedHashOverride
 
         def initialize(app, env)
@@ -26,8 +29,7 @@ module VagrantPlugins
           end
 
           # FIX MULTIPLE NETWORK INTERFACES
-          hostname = env[:machine].config.vm.hostname
-          hostname = 'vagrant' if hostname.nil?
+          hostname = machine_hostname(env[:machine])
 
           initialization = {
             host_name: hostname,

--- a/lib/vagrant-ovirt4/config.rb
+++ b/lib/vagrant-ovirt4/config.rb
@@ -29,6 +29,7 @@ module VagrantPlugins
       attr_accessor :optimized_for
       attr_accessor :description
       attr_accessor :comment
+      attr_accessor :vmname
       attr_accessor :disks
 
       def initialize
@@ -55,6 +56,7 @@ module VagrantPlugins
         @optimized_for     = UNSET_VALUE
         @description       = UNSET_VALUE
         @comment           = UNSET_VALUE
+        @vmname            = UNSET_VALUE
         @disks             = []
 
       end
@@ -109,6 +111,7 @@ module VagrantPlugins
         @optimized_for = nil if @optimized_for == UNSET_VALUE
         @description = '' if @description == UNSET_VALUE
         @comment = '' if @comment == UNSET_VALUE
+        @vmname = nil if @vmname == UNSET_VALUE
 
         unless optimized_for.nil?
           raise "Invalid 'optimized_for'. Must be one of #{OvirtSDK4::VmType.constants.map { |s| "'#{s.downcase}'" }.join(' ')}" unless OvirtSDK4::VmType.constants.include? optimized_for.upcase.to_sym

--- a/lib/vagrant-ovirt4/util/machine_names.rb
+++ b/lib/vagrant-ovirt4/util/machine_names.rb
@@ -1,0 +1,21 @@
+module VagrantPlugins
+  module OVirtProvider
+    module Util
+      module MachineNames
+        DEFAULT_NAME = 'vagrant'.freeze
+
+      module_function
+
+        def machine_hostname(machine)
+          machine.config.vm.hostname || DEFAULT_NAME
+        end
+
+        def machine_vmname(machine)
+          machine.provider_config.vmname || machine_hostname(machine)
+        end
+      end
+    end
+  end
+end
+
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,3 @@
 require 'vagrant'
+
+require_relative 'support/shared_context'

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -1,0 +1,39 @@
+require 'vagrant-ovirt4/config'
+
+shared_context 'provider:action' do
+  let(:app) { double('app') }
+
+  let(:env) {
+    {
+      connection: double('connection',
+        system_service: double('system_service', disks_service: double('disks_service'))
+      ),
+      machine: double('machine',
+        provider: double('provider'),
+        provider_config: VagrantPlugins::OVirtProvider::Config.new,
+        name: 'machname',
+        id: 'ID',
+        config: double('config',
+          vm: double('vm_config',
+            networks: [],
+          ),
+        ),
+      ),
+      ui: double('ui'),
+      vms_service: double('vms_service'),
+    }
+  }
+
+  let(:vm_service) {
+    double('vm_service',
+      disk_attachments_service: double('disk_attachments_service', list: []),
+      get: double('get'),
+    )
+  }
+
+  before do
+    allow(app).to receive(:call)
+    allow(env[:vms_service]).to receive(:vm_service).with(env[:machine].id).and_return(vm_service)
+    env[:machine].provider_config.finalize!
+  end
+end

--- a/spec/vagrant-ovirt4/action/create_vm_spec.rb
+++ b/spec/vagrant-ovirt4/action/create_vm_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'vagrant-ovirt4/action/create_vm'
+require 'vagrant-ovirt4/config'
+
+describe VagrantPlugins::OVirtProvider::Action::CreateVM do
+  include_context 'provider:action'
+
+  let(:vm) { double('vm', id: 'ID') }
+
+  subject(:action) { described_class.new(app, env) }
+
+  before do
+    allow(env[:ui]).to receive(:info)
+    allow(env[:machine]).to receive(:"id=").with(vm.id)
+    allow(vm_service.get).to receive(:status).and_return('down')
+  end
+
+  context 'given a custom vmname' do
+    let(:vmname) { 'VMNAME' }
+
+    it 'uses that as the name for machine creation' do
+      env[:machine].provider_config.vmname = vmname
+      expect(env[:vms_service]).to receive(:add).with(hash_including(name: vmname)).and_return(vm)
+      action.call(env)
+    end
+  end
+
+  context 'given no custom vmname' do
+    context 'given a custom hostname' do
+      let(:hostname) { 'HOSTNAME' }
+
+      it 'uses that as the name for machine creation' do
+        expect(env[:machine].config.vm).to receive(:hostname).and_return(hostname)
+        expect(env[:vms_service]).to receive(:add).with(hash_including(name: hostname)).and_return(vm)
+        action.call(env)
+      end
+    end
+
+    context 'given no custom hostname' do
+      it 'uses a default name for machine creation' do
+        expect(env[:machine].config.vm).to receive(:hostname)
+        expect(env[:vms_service]).to receive(:add).with(hash_including(name: 'vagrant')).and_return(vm)
+        action.call(env)
+      end
+    end
+  end
+end

--- a/spec/vagrant-ovirt4/action/start_vm_spec.rb
+++ b/spec/vagrant-ovirt4/action/start_vm_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+require 'vagrant-ovirt4/action/start_vm'
+require 'vagrant-ovirt4/config'
+
+describe VagrantPlugins::OVirtProvider::Action::StartVM do
+  include_context 'provider:action'
+
+  subject(:action) { described_class.new(app, env) }
+
+  before do
+    allow(env[:ui]).to receive(:info)
+    allow(vm_service.get).to receive(:status).and_return('nominal')
+    allow(vm_service).to receive(:start)
+  end
+
+  def vm_initialization_hash_including_hostname(hostname)
+    hash_including(vm: hash_including(initialization: hash_including(host_name: hostname)))
+  end
+
+  context 'given a custom hostname' do
+    let(:hostname) { 'HOSTNAME' }
+
+    it 'uses that as the hostname for machine initialization' do
+      expect(env[:machine].config.vm).to receive(:hostname).and_return(hostname)
+      expect(vm_service).to receive(:start).with(vm_initialization_hash_including_hostname(hostname))
+      action.call(env)
+    end
+  end
+
+  context 'given no custom hostname' do
+    it 'uses a default value as the hostname for machine initialization' do
+      expect(env[:machine].config.vm).to receive(:hostname)
+      expect(vm_service).to receive(:start).with(vm_initialization_hash_including_hostname('vagrant'))
+      action.call(env)
+    end
+  end
+end


### PR DESCRIPTION
This changeset introduces the `vmname` option, which represents the name that oVirt should attach to the VM (as distinct from its hostname).

Inspired by [the hyperv provider's `vmname` option](https://github.com/hashicorp/vagrant/blob/3d68e16f1b5d616f879d24f48dac2598acac0a38/plugins/providers/hyperv/config.rb#L28-L29)

If `vmname` is unspecified, use `config.vm.hostname`; if this is unspecified, use the default value "vagrant" (this mirrors the existing naming logic, but as a fallback).

This changeset introduces the utility module `Util::MachineNames` that provides the instance method `#machine_vmname` for inferring the `vmname` of a Vagrant-managed machine, and the instance method
`#machine_hostname` for inferring the hostname.  It's wrapped into a module to DRY up the fallback naming logic -- `#machine_vmname` defaults to returning the return value of `#machine_hostname` if no explicit `vmname` was provided by the user.

Motivation: under the hood, `libvirt-based` machines have to abide by `systemd-machined`'s machine naming rules, including a [64-character length limit](https://github.com/systemd/systemd/blob/0da2bb7414a53957287aacc5811fc7c52c13b730/src/basic/hostname-util.c#L133-L134). `systemd-machined` also requires machine names to be valid hostnames], which means (among other things) that [they cannot end in a "."](https://github.com/systemd/systemd/blob/0da2bb7414a53957287aacc5811fc7c52c13b730/src/basic/hostname-util.c#L128-L129).  Older versions of `libvirt` do not check for a trailing "." when truncating machine names to 64 characters, which leads to a fatal error creating a machine when the 64th character happens to be "." (see [here](https://github.com/libvirt/libvirt/commit/2695191a44eb7375225b4ad073825ed3563a172a) for the `libvirt` changeset that fixes the bug).  

For older oVirt installations, the `vmname` setting helps because we can set it to a value that contains no
dots, while still setting the machine **hostname** to a value that does contain dots.

Thanks in advance for your consideration!