### PR TITLE
Enable oVirt connection debugging when VAGRANT_LOG=info

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ end
   1. `username` => The username for the API. Required. String. No default value.
   1. `password` => The password for the API. Required. String. No default value.
   1. `insecure` => Allow connecting to SSL sites without certificates. Optional. Bool. Default is `false`
-  1. `debug` => Turn on additional log statements. Optional. Bool. Default is `false`.
+  1. `debug` => Turn on additional log statements. Optional. Bool. Default is
+     `true` if Vagrant's logging verbosity is set to `info` or above
+     (`VAGRANT_LOG={info,debug,...}`); otherwise, the default is `false`.
   1. `timeout` => Per [the oVirt SDK docs][OvirtSDK4::Connection#initialize],
      "The maximun (_sic_) total time to wait for the response, in seconds. A value of
      zero (the default) means wait for ever." Optional. Integer. Uses the

--- a/lib/vagrant-ovirt4/action/connect_ovirt.rb
+++ b/lib/vagrant-ovirt4/action/connect_ovirt.rb
@@ -19,11 +19,19 @@ module VagrantPlugins
           conn_attr[:url] = "#{config.url}"
           conn_attr[:username] = config.username if config.username
           conn_attr[:password] = config.password if config.password
-          conn_attr[:debug] = config.debug if config.debug
           conn_attr[:insecure] = true if config.insecure
           conn_attr[:headers] = {'Filter' => true} if config.filtered_api
           conn_attr[:timeout] = config.timeout unless config.timeout.nil?
           conn_attr[:connect_timeout] = config.connect_timeout unless config.connect_timeout.nil?
+
+          # Respect VAGRANT_LOG setting -- any level at least as verbose as
+          # "info" will result in logging oVirt connection debugging messages
+          # (read: libcurl verbose output).
+          conn_attr[:debug] = config.debug or @logger.info?
+
+          # Inject our own logger so that messages are namespaced under
+          # "connect_ovirt"
+          conn_attr[:log] = @logger
 
           @logger.info("Connecting to oVirt (#{config.url}) ...")
           ovirt_connection = OvirtSDK4::Connection.new(conn_attr)


### PR DESCRIPTION
or a more verbose level.  This makes the connection logging output track the user's global logging level.

Thanks in advance for your consideration!