### PR TITLE
read_ssh_info: return nil on IPv4 lookup failure

### DIFF
--- a/spec/vagrant-ovirt4/action/read_ssh_info_spec.rb
+++ b/spec/vagrant-ovirt4/action/read_ssh_info_spec.rb
@@ -17,7 +17,7 @@ describe VagrantPlugins::OVirtProvider::Action::ReadSSHInfo do
     expect(action).to receive(:call).with(env)
     action.call(env)
   end
-  
+
   context 'unknown API error' do
     before do
       allow(env.machine).to receive(:id).and_return('wat')
@@ -25,35 +25,35 @@ describe VagrantPlugins::OVirtProvider::Action::ReadSSHInfo do
       allow(env.vms_service.vm_service).to receive(:get).and_raise('boom')
 
     end
-  
-    it 'continues the middleware chain' do
+
+    it 'returns nil' do
       expect(app).to receive(:call).with(env)
       action.call(env)
-      expect(env.machine_ssh_info).to eq(:not_created)
+      expect(env.machine_ssh_info).to be_nil
     end
-
   end
 
   context 'machine does not exist' do
     before do
       allow(env.machine).to receive(:id).and_return(nil)
     end
-  
-    it 'continues the middleware chain' do
+
+    it 'returns nil' do
       expect(app).to receive(:call).with(env)
       action.call(env)
-      expect(env.machine_ssh_info).to eq(:not_created)
+      expect(env.machine_ssh_info).to be_nil
     end
-
   end
 
   context 'machine exists' do
+    let(:port)     { 44 }
+
     before do
       allow(env.machine).to receive(:id).and_return('wat')
       allow(env.machine).to receive(:config).and_return(OpenStruct.new({
         ssh: OpenStruct.new({
-          guest_port: 44,
-        }),
+          guest_port: port
+        })
       }))
       allow(env.vms_service).to receive(:vm_service).and_return({})
       allow(env.vms_service.vm_service).to receive(:get).and_return({})
@@ -61,13 +61,27 @@ describe VagrantPlugins::OVirtProvider::Action::ReadSSHInfo do
       allow(env.vms_service.vm_service.nics_service).to receive(:list).and_return({})
       allow(env.vms_service.vm_service.get).to receive(:status).and_return('active')
     end
-  
-    it 'continues the middleware chain' do
-      expect(app).to receive(:call).with(env)
-      action.call(env)
-      expect(env.machine_ssh_info).to eq({:host=>nil, :port=>44, :username=>nil, :private_key_path=>nil, :forward_agent=>nil, :forward_x11=>nil})
+
+    context 'with no IP addresses defined' do
+      it 'returns nil' do
+        expect(app).to receive(:call).with(env)
+        action.call(env)
+        expect(env.machine_ssh_info).to be_nil
+      end
     end
 
+    context 'with at least one IP address defined' do
+      let(:host) { '10.10.10.10' }
+
+      before do
+        allow(action).to receive(:first_active_ipv4_address).and_return(host)
+      end
+
+      it 'returns filled-out SSH information' do
+        expect(app).to receive(:call).with(env)
+        action.call(env)
+        expect(env.machine_ssh_info).to eq(host: host, port: port, username: nil, private_key_path: nil, forward_agent: nil, forward_x11: nil)
+      end
+    end
   end
 end
-


### PR DESCRIPTION
Rather than returning `{ host: nil, ... }`, as the absence of an associated IPv4 address means that the target machine is not yet ready for SSH.

Additionally, make `OVirtProvider::Action::ReadSSHInfo#read_ssh_info` (and thus `OVirtProvider::Provider#ssh_info`) return `nil` rather than `:not_created` in the other scenarios in which SSH is not yet ready (e.g., the machine is not yet created).  This accords with other Vagrant providers:

* https://github.com/hashicorp/vagrant/blob/3d68e16f1b5d616f879d24f48dac2598acac0a38/plugins/providers/docker/provider.rb#L145-L173
* https://github.com/hashicorp/vagrant/blob/3d68e16f1b5d616f879d24f48dac2598acac0a38/plugins/providers/hyperv/provider.rb#L88-L110
* https://github.com/hashicorp/vagrant/blob/3d68e16f1b5d616f879d24f48dac2598acac0a38/plugins/providers/virtualbox/provider.rb#L68-L80
* https://github.com/mitchellh/vagrant-aws/blob/43e7ec2eb425fdf0223910522b6e91a92329f00f/lib/vagrant-aws/action/read_ssh_info.rb#L20-L49

And indeed other Vagrant code treats `nil` as a special sentinel value signifying that target machine is not ready for SSH:

* https://github.com/hashicorp/vagrant/blob/3d68e16f1b5d616f879d24f48dac2598acac0a38/plugins/communicators/ssh/communicator.rb#L62-L70
* https://github.com/hashicorp/vagrant/blob/3d68e16f1b5d616f879d24f48dac2598acac0a38/plugins/communicators/ssh/communicator.rb#L170-L172
* https://github.com/hashicorp/vagrant/blob/3d68e16f1b5d616f879d24f48dac2598acac0a38/plugins/communicators/ssh/communicator.rb#L397-L400

Note that I factored out the IP address inference logic into the private instance method `OVirtProvider::Action::ReadSSHInfo#first_active_ipv4_address`; I did this in order to facilitate easier mocking in `read_ssh_info_spec.rb`.

Thanks in advance for your consideration!