### PR TITLE
Default to disabling run-once mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Vagrant.configure("2") do |config|
     ovirt.filtered_api = true #see http://www.ovirt.org/develop/release-management/features/infra/user-portal-permissions/
     ovirt.cluster = 'Default'
     ovirt.vmname = 'my-vm'
+    ovirt.run_once = false
     ovirt.template = 'Vagrant-Centos7-test'
     ovirt.console = 'vnc'
     ovirt.disk_size = '15 GiB' # only growing is supported. works the same way as below memory settings
@@ -138,6 +139,7 @@ end
   1. `vmname` => Sets the name of the VM. Optional. String. Default is
      `config.vm.hostname`, if defined, otherwise `"vagrant"`.
     a. Is the 'name' in the Virtual Machine tab of the UI
+  1. `run_once` => Launch VM in run-once mode. Optional. Default is `false`.
   1. `template` => The name of the template to use for creation. Required. String. No Default value.
   1. `cluster` => The name of the ovirt cluster to create within. Required. String. No Default value.
   1. `console` => The type of remote viewing protocol to use. Required. String. No Default value.

--- a/lib/vagrant-ovirt4/action/start_vm.rb
+++ b/lib/vagrant-ovirt4/action/start_vm.rb
@@ -83,6 +83,7 @@ module VagrantPlugins
           vm_configuration = {
             initialization: initialization,
             placement_policy: {},
+            run_once: config.run_once
           }
 
           vm_configuration[:placement_policy][:hosts] = [{ :name => config.placement_host }] unless config.placement_host.nil?

--- a/lib/vagrant-ovirt4/config.rb
+++ b/lib/vagrant-ovirt4/config.rb
@@ -33,6 +33,7 @@ module VagrantPlugins
       attr_accessor :disks
       attr_accessor :timeout
       attr_accessor :connect_timeout
+      attr_accessor :run_once
 
       def initialize
         @url               = UNSET_VALUE
@@ -61,6 +62,7 @@ module VagrantPlugins
         @vmname            = UNSET_VALUE
         @timeout           = UNSET_VALUE
         @connect_timeout   = UNSET_VALUE
+        @run_once          = UNSET_VALUE
         @disks             = []
 
       end
@@ -118,6 +120,7 @@ module VagrantPlugins
         @vmname = nil if @vmname == UNSET_VALUE
         @timeout = nil if @timeout == UNSET_VALUE
         @connect_timeout = nil if @connect_timeout == UNSET_VALUE
+        @run_once = @run_once == UNSET_VALUE ? false : !!@run_once
 
         unless optimized_for.nil?
           raise "Invalid 'optimized_for'. Must be one of #{OvirtSDK4::VmType.constants.map { |s| "'#{s.downcase}'" }.join(' ')}" unless OvirtSDK4::VmType.constants.include? optimized_for.upcase.to_sym

--- a/spec/vagrant-ovirt4/action/start_vm_spec.rb
+++ b/spec/vagrant-ovirt4/action/start_vm_spec.rb
@@ -9,6 +9,7 @@ describe VagrantPlugins::OVirtProvider::Action::StartVM do
 
   before do
     allow(env[:ui]).to receive(:info)
+    allow(env[:machine].config.vm).to receive(:hostname)
     allow(vm_service.get).to receive(:status).and_return('nominal')
     allow(vm_service).to receive(:start)
   end
@@ -29,8 +30,24 @@ describe VagrantPlugins::OVirtProvider::Action::StartVM do
 
   context 'given no custom hostname' do
     it 'uses a default value as the hostname for machine initialization' do
-      expect(env[:machine].config.vm).to receive(:hostname)
       expect(vm_service).to receive(:start).with(vm_initialization_hash_including_hostname('vagrant'))
+      action.call(env)
+    end
+  end
+
+  context 'given a custom run_once setting' do
+    [true, false].each do |value|
+      it 'uses that setting' do
+        env[:machine].provider_config.run_once = value
+        expect(vm_service).to receive(:start).with(hash_including(vm: hash_including(run_once: value)))
+        action.call(env)
+      end
+    end
+  end
+
+  context 'given no custom run_once setting' do
+    it 'defaults to false' do
+      expect(vm_service).to receive(:start).with(hash_including(vm: hash_including(run_once: false)))
       action.call(env)
     end
   end

--- a/spec/vagrant-ovirt4/config_spec.rb
+++ b/spec/vagrant-ovirt4/config_spec.rb
@@ -50,6 +50,7 @@ describe VagrantPlugins::OVirtProvider::Config do
     its("optimized_for")     { should be_nil }
     its("description")       { should == '' }
     its("comment")           { should == '' }
+    its("run_once")          { should be false }
 
   end
 
@@ -149,6 +150,29 @@ describe VagrantPlugins::OVirtProvider::Config do
             expect(error).to be_a(RuntimeError)
             expect(error.message).to match(/nonnegative integer/)
           }
+        end
+      end
+    end
+
+  end
+
+  describe "overriding run_once defaults" do
+    context "given truthy values" do
+      [Object.new, {}, true, 1, 0].each do |value|
+        it "should convert #{value.inspect} to 'true'" do
+          instance.run_once = value
+          instance.finalize!
+          expect(instance.run_once).to be true
+        end
+      end
+    end
+
+    context "given falsey values" do
+      [false, nil].each do |value|
+        it "should convert #{value.inspect} to 'false'" do
+          instance.run_once = value
+          instance.finalize!
+          expect(instance.run_once).to be false
         end
       end
     end


### PR DESCRIPTION
and instead start VMs in "normal" mode.

This closes #127 and #147 (addressing the request in the latter for making the `run_once` parameter configurable).