### PR TITLE
Set iface name and mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Vagrant.configure("2") do |config|
   config.vm.network :private_network,
     :ovirt__network_name => 'ovirtmgmt' #DHCP
     # Static configuration
-    #:ovirt__ip => '192.168.2.198', :ovirt__network_name => 'ovirtmgmt', :ovirt__gateway => '192.168.2.125', :ovirt__netmask => '255.255.0.0', :ovirt__dns_servers => '192.168.2.1', :ovirt__dns_search => 'test.local'
+    #:ovirt__ip => '192.168.2.198', :ovirt__network_name => 'ovirtmgmt', :ovirt__gateway => '192.168.2.125', :ovirt__netmask => '255.255.0.0', :ovirt__dns_servers => '192.168.2.1', :ovirt__dns_search => 'test.local', :ovirt__mac => "0200004F49AB"
     # Static configuration with biosdevname. Guest OS assigns interface names (ens3, em1 or something else). ovirt__interface_name has to match that name.
     #:ovirt__ip => '192.168.2.198', :ovirt__network_name => 'ovirtmgmt', :ovirt__gateway => '192.168.2.125', :ovirt__netmask => '255.255.0.0', :ovirt__dns_servers => '192.168.2.1', :ovirt__dns_search => 'test.local', :ovirt__interface_name => 'ens3'
 

--- a/lib/vagrant-ovirt4/action/create_network_interfaces.rb
+++ b/lib/vagrant-ovirt4/action/create_network_interfaces.rb
@@ -91,4 +91,3 @@ module VagrantPlugins
     end
   end
 end
-

--- a/lib/vagrant-ovirt4/action/create_network_interfaces.rb
+++ b/lib/vagrant-ovirt4/action/create_network_interfaces.rb
@@ -37,7 +37,7 @@ module VagrantPlugins
 
             iface_options = scoped_hash_override(options, :ovirt)
             @logger.info("Interface options: #{iface_options}")
-
+            #env[:ui].info("Interface options:  #{iface_options}")
             begin
               nics_service = env[:vms_service].vm_service(env[:machine].id).nics_service
               if iface_options.nil?
@@ -60,16 +60,34 @@ module VagrantPlugins
                 raise Errors::NetworkNotFoundError, :network_name => iface_options[:network_name] if network_profile_id.nil? and !iface_options[:network_name].nil?
 
                 # quick and dirty way to look for a 'nic#' that is not already attached to the machine
-                iface = (("nic1".."nic8").flat_map { |x| x } - env[:vms_service].vm_service(env[:machine].id).nics_service.list.map(&:name)).first rescue "vagrant_nic1"
+                if iface_options[:ovirt__interface_name].nil?
+                  iface = (("nic1".."nic8").flat_map { |x| x } - env[:vms_service].vm_service(env[:machine].id).nics_service.list.map(&:name)).first rescue "vagrant_nic1"
+                else
+                  iface = iface_options[:ovirt__interface_name]
+                end
                 @logger.info("Creating network interface #{iface}")
-                nics_service.add(
-                  OvirtSDK4::Nic.new(
-                    name: iface,
-                    vnic_profile: {
-                      id: network_profile_id
-                    }
+                if !iface_options[:ovirt__mac].nil?
+                  interface_address = iface_options[:ovirt__mac].scan(/.{2}|.+/).join(":").downcase
+                  mac_address = OvirtSDK4::Mac.new( address: interface_address )
+                  nics_service.add(
+                    OvirtSDK4::Nic.new(
+                      name: iface,
+                      vnic_profile: {
+                        id: network_profile_id
+                      },
+                      mac: mac_address
+                    )
                   )
-                )
+                else
+                  nics_service.add(
+                    OvirtSDK4::Nic.new(
+                      name: iface,
+                      vnic_profile: {
+                        id: network_profile_id
+                      }
+                    )
+                  )
+                end
               end
             rescue => e
               if config.debug


### PR DESCRIPTION
Through this modification it is possible to manage the name of the network interface and its mac address on oVirt.
This is useful on some providers that apply filtering at the MAC level.